### PR TITLE
Cops 648

### DIFF
--- a/nginx-ingress-vault/README.md
+++ b/nginx-ingress-vault/README.md
@@ -4,16 +4,30 @@ This is a simple nginx Ingress controller. Expect it to grow up. See [Ingress co
 
 This version includes SSL support, integrated with HashiCorp Vault and access and error logs, which go to the container stdout/stderr by default.
 
+## Build
+
+To create a build tagged as "dev" for testing use:
+
+```
+./build.sh --tag dev --publish --force
+```
+
+To create a final version tagged as latest and ready for use:
+
+```
+./build.sh --patch --latest --publish
+```
+
+For help regarding the build script:
+
+```
+./build --help
+```
+
 ## Installation
 If using a MacBook, edit .bash_profile to include:
 export GOOS="linux"
 export GOARCH="amd64"
-
-```
-go build controller.go && docker rmi devlm/nginx-ingress:latest; docker build -t devlm/nginx-ingress:latest . && docker push devlm/nginx-ingress:latest
-```
-
-replacing devlm/nginx-ingress with a repo of your choice. There is a pre-built container at devlm/nginx-ingress on docker hub if required.
 
 Access to Vault is predicated on the following:
 

--- a/nginx-ingress-vault/build.sh
+++ b/nginx-ingress-vault/build.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -x
-
 DRY_RUN=false
 
 VERSION_SOURCE_FILE="controller.go"
@@ -16,6 +14,8 @@ MAJOR=false
 MINOR=false
 PATCH=false
 UPREV=false
+TAG_LATEST=false
+TAG_EXISTS=false
 
 VERSION_LINE=`grep -oEi "const[\t ]+version[\t ]*=[\t ]*\"[0-9]+\.[0-9]+\.[0-9]+\"" $VERSION_SOURCE_FILE`
 VERSION=`echo $VERSION_LINE | grep -oEi "[0-9]+\.[0-9]+\.[0-9]+"`
@@ -26,6 +26,20 @@ TAG=$VERSION
 
 Showhelp () {
   echo "build.sh <options>"
+  echo ""
+  echo "  Options"
+  echo "    -? or -h or --help - Show this screen"
+  echo "    -P or --publish - Publish the build to the docker registry"
+  echo "    -f or --force - Force push the build to the docker registry even if it already exists"
+  echo "    -t <tag> or --tag <tag> - What tag to use when pushing"
+  echo "    -l or --tag-latest - Publish to docker registry as latest"
+  echo "    -v <version> or --version <version> - Composite version number to deploy"
+  echo "    -M or --major - Increment Major version number, reset minor and patch"
+  echo "    -m or --minor - Increment Minor version number, reset patch"
+  echo "    -p or --patch - Increment Patch version number"
+  echo "    -s or --source-file <fileName> - Set the source file to work against, defaults to \"$VERSION_SOURCE_FILE\""
+  echo "    --no-build - Don't execute go build"
+  echo "    --dry-run - Perform a dry run, nothing will actually change, but all commands will be output"
   exit 0
 }
 
@@ -71,6 +85,9 @@ do
       ;;
     --dry-run)
       DRY_RUN=true
+      ;;
+    -l|--tag-latest)
+      TAG_LATEST=true
       ;;
     -\?|-h|--help)
       Showhelp
@@ -119,6 +136,18 @@ if [[ $PUBLISH ]]; then
       echo "Tag $TAG already exists in the registry!"
       exit 1
     fi
+  else # We want to force a push even if the tag exists
+    if [[ $VERSION == $TAG ]]; then
+      CHECK=`echo $PUBLISHED_VERSIONS | grep -o "$VERSION"`
+      if [[ "$CHECK" != "" ]]; then
+        TAG_EXISTS=true
+      fi
+    else
+      CHECK=`echo $PUBLISHED_TAGS | grep -o "$TAG"`
+      if [[ "$CHECK" != "" ]]; then
+        TAG_EXISTS=true
+      fi
+    fi
   fi
 fi
 
@@ -152,7 +181,14 @@ if [[ $PUBLISH == true ]]; then
     echo docker build -t $REPOSITORY:$TAG .
     echo docker push $REPOSITORY:$TAG
   else
+    if [[ $TAG_EXISTS == true ]]; then
+      docker rmi $REPOSITORY:$TAG
+    fi
     docker build -t $REPOSITORY:$TAG .
     docker push $REPOSITORY:$TAG
+    if [[ $TAG_LATEST == true ]]; then
+      docker rmi $REPOSITORY:latest
+      docker push $REPOSITORY:latest
+    fi
   fi
 fi

--- a/nginx-ingress-vault/build.sh
+++ b/nginx-ingress-vault/build.sh
@@ -161,7 +161,12 @@ if [[ "$CODE_VERSION" != "$VERSION" ]]; then
   if [[ $DRY_RUN == true ]]; then
     echo sed -i "s/$VERSION_LINE/$NEW_VERSION_LINE/" $VERSION_SOURCE_FILE
   else
+    echo "Updating $VERSION_SOURCE_FILE with version $VERSION"
     sed -i "s/$VERSION_LINE/$NEW_VERSION_LINE/" $VERSION_SOURCE_FILE
+    git add $VERSION_SOURCE_FILE
+    git commit -m "v$VERSION"
+    echo "Pushing version tag to repo"
+    git push
   fi
 fi
 

--- a/nginx-ingress-vault/build.sh
+++ b/nginx-ingress-vault/build.sh
@@ -181,7 +181,7 @@ if [[ $BUILD == true ]]; then
 fi
 
 if [[ $PUBLISH == true ]]; then
-  echo "Publishing $VERSION"
+  echo "Publishing $VERSION as tag $TAG"
   if [[ $DRY_RUN == true ]]; then
     echo docker build -t $REPOSITORY:$TAG .
     echo docker push $REPOSITORY:$TAG
@@ -192,6 +192,7 @@ if [[ $PUBLISH == true ]]; then
     docker build -t $REPOSITORY:$TAG .
     docker push $REPOSITORY:$TAG
     if [[ $TAG_LATEST == true ]]; then
+      echo "Publishing $VERSION as tag latest"
       docker rmi $REPOSITORY:latest
       docker push $REPOSITORY:latest
     fi

--- a/nginx-ingress-vault/build.sh
+++ b/nginx-ingress-vault/build.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+
+set -x
+
+DRY_RUN=false
+
+VERSION_SOURCE_FILE="controller.go"
+REPOSITORY="pearsontechnology/nginx-ingress"
+
+BUILD=true
+
+FORCE=false
+PUBLISH=false
+
+MAJOR=false
+MINOR=false
+PATCH=false
+UPREV=false
+
+VERSION_LINE=`grep -oEi "const[\t ]+version[\t ]*=[\t ]*\"[0-9]+\.[0-9]+\.[0-9]+\"" $VERSION_SOURCE_FILE`
+VERSION=`echo $VERSION_LINE | grep -oEi "[0-9]+\.[0-9]+\.[0-9]+"`
+CODE_VERSION=$VERSION
+PUBLISHED_TAGS=`wget -q https://registry.hub.docker.com/v1/repositories/$REPOSITORY/tags -O - | jq ".[].name" -r`
+PUBLISHED_VERSIONS=`echo $PUBLISHED_TAGS | grep -oEi "[0-9]+\.[0-9]+\.[0-9]+"`
+TAG=$VERSION
+
+Showhelp () {
+  echo "build.sh <options>"
+  exit 0
+}
+
+while [[ $# > 0 ]]
+do
+  key="$1"
+  case $key in
+    --publish|-P)
+      PUBLISH=true
+      ;;
+    --force|-f)
+      FORCE=true
+      ;;
+    --tag|-t)
+      TAG="$2"
+      shift
+      ;;
+    --version|-v)
+      if [[ "$TAG" == "$VERSION" ]]; then
+        TAG="$2"
+      fi
+      VERSION="$2"
+      shift
+      ;;
+    -M|--major)
+      MAJOR=true
+      UPREV=true
+      ;;
+    -m|--minor)
+      MINOR=true
+      UPREV=true
+      ;;
+    -p|--patch)
+      PATCH=true
+      UPREV=true
+      ;;
+    -s|--source-file)
+      VERSION_SOURCE_FILE="$2"
+      shift
+      ;;
+    --no-build)
+      BUILD=false
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      ;;
+    -\?|-h|--help)
+      Showhelp
+      ;;
+    *)
+    # unknown option
+    ;;
+  esac
+  shift # past argument or value
+done
+
+if [[ $UPREV == true ]]; then
+  a=( ${VERSION//./ } )
+  if [[ $MAJOR == true ]]; then
+    ((a[0]++))
+    a[1]=0
+    a[2]=0
+  fi
+
+  if [[ $MINOR == true ]]; then
+    ((a[1]++))
+    a[2]=0
+  fi
+
+  if [[ $PATCH == true ]]; then
+    ((a[2]++))
+  fi
+  NEW_VERSION="${a[0]}.${a[1]}.${a[2]}"
+  if [[ "$TAG" == "$VERSION" ]]; then
+    TAG=$NEW_VERSION
+  fi
+  VERSION=$NEW_VERSION
+fi
+
+if [[ $PUBLISH ]]; then
+  if [[ $FORCE != true ]]; then
+    if [[ $VERSION == $TAG ]]; then
+      CHECK=`echo $PUBLISHED_VERSIONS | grep -o "$VERSION"`
+      if [[ "$CHECK" != "" ]]; then
+        echo "Version $VERSION already exists in the registry!"
+        exit 1
+      fi
+    fi
+    CHECK=`echo $PUBLISHED_TAGS | grep -o "$TAG"`
+    if [[ "$CHECK" != "" ]]; then
+      echo "Tag $TAG already exists in the registry!"
+      exit 1
+    fi
+  fi
+fi
+
+if [[ "$CODE_VERSION" != "$VERSION" ]]; then
+  NEW_VERSION_OK=`echo $VERSION | grep  -oEi "[0-9]+\.[0-9]+\.[0-9]+"`
+  if [[ "$NEW_VERSION_OK" == "" ]]; then
+    echo "Invalid new version specified: $VERSION"
+    exit 1
+  fi
+  NEW_VERSION_LINE="const version = \"$VERSION\""
+  if [[ $DRY_RUN == true ]]; then
+    echo sed -i "s/$VERSION_LINE/$NEW_VERSION_LINE/" $VERSION_SOURCE_FILE
+  else
+    sed -i "s/$VERSION_LINE/$NEW_VERSION_LINE/" $VERSION_SOURCE_FILE
+  fi
+fi
+
+if [[ $BUILD == true ]]; then
+  echo "Building version: "$VERSION
+
+  if [[ $DRY_RUN == true ]]; then
+    echo go build "$VERSION_SOURCE_FILE"
+  else
+    go build "$VERSION_SOURCE_FILE"
+  fi
+fi
+
+if [[ $PUBLISH == true ]]; then
+  echo "Publishing $VERSION"
+  if [[ $DRY_RUN == true ]]; then
+    echo docker build -t $REPOSITORY:$TAG .
+    echo docker push $REPOSITORY:$TAG
+  else
+    docker build -t $REPOSITORY:$TAG .
+    docker push $REPOSITORY:$TAG
+  fi
+fi

--- a/nginx-ingress-vault/controller.go
+++ b/nginx-ingress-vault/controller.go
@@ -33,7 +33,7 @@ import (
     log "github.com/Sirupsen/logrus"
 )
 
-const version = "1.8.2"
+const version = "1.8.3"
 
 func main() {
 

--- a/nginx-ingress-vault/nginx.conf.tmpl
+++ b/nginx-ingress-vault/nginx.conf.tmpl
@@ -65,18 +65,18 @@ http {
     }
   }
 {{range $i := .}}
-
-  {{ if $i.BlueGreen }}
-  {{ range $path := $i.Paths }}
-  map $http_x_bluegreen_backend ${{ $i.Name }}_{{ replace $path.Service "-" "_" }}_backend {
-    default "{{ $i.DefaultUrl $path }}";
-    {{ $url := $i.BlueUrl $path }}
-    blue    "{{ $url }}";
-    {{ $url := $i.GreenUrl $path }}
-    green   "{{ $i.GreenUrl $path }}";
+{{if $i.Host}}
+  {{if $i.BlueGreen}}
+  {{range $path := $i.Paths}}
+  map $http_x_bluegreen_backend ${{$i.Name}}_{{replace $path.Service "-" "_"}}_backend {
+    default "{{$i.DefaultUrl $path}}";
+    {{$url := $i.BlueUrl $path}}
+    blue    "{{$url}}";
+    {{$url := $i.GreenUrl $path}}
+    green   "{{$i.GreenUrl $path}}";
   }
-  {{ end }}
-  {{ end }}
+  {{end}}{{/* range $path := $i.Paths */}}
+  {{end}}{{/* if $i.BlueGreen */}}
   {{if not $i.Nonssl}}
   server {
   # cops-479 - Add 301 redirect if httpsOnly is set to true.
@@ -85,17 +85,19 @@ http {
     resolver kube-dns.kube-system.svc.cluster.local;
     return  301  https://$server_name$request_uri;
   }
-  {{end}}
+  {{end}}{{/* if not $i.Nonssl */}}
 
   server {
     server_name {{$i.Host}};
     resolver kube-dns.kube-system.svc.cluster.local;
-{{if $i.Ssl}}
+    {{if $i.Ssl}}
     listen 443 ssl;
     ssl_certificate   /etc/nginx/certs/{{$i.Host}}.crt;
     ssl_certificate_key /etc/nginx/certs/{{$i.Host}}.key;
-{{end}}
-{{if $i.Nonssl}}    listen 80;{{end}}
+    {{end}}{{/* if $i.Ssl */}}
+    {{if $i.Nonssl}}
+    listen 80;
+    {{end}}{{/* if $i.Nonssl */}}
     # cops-165 - This will intercept the back-end errors and forward a custom
     # error page in the Nginx node.
     proxy_intercept_errors on;
@@ -110,21 +112,23 @@ http {
         root /usr/share/nginx/html;
     }
 
-{{ range $path := $i.Paths }}
+    {{range $path := $i.Paths}}
     location {{$path.URI}} {
       proxy_set_header Host $host;
       # cops-374 - Will forward the Nginx pod name as a custom header
       add_header X-Loadbalancer-Id {{$i.GetPodName}};
-      {{ if $i.BlueGreen }}
-      # proxy_pass ${{ $i.Name }}_{{ replace $path.Service "-" "_"}}_backend;
-      set $upstream_{{ $i.Name }}_{{ replace $path.Service "-" "_"}}_backend ${{ $i.Name }}_{{ replace $path.Service "-" "_"}}_backend;
-      proxy_pass $upstream_{{ $i.Name }}_{{ replace $path.Service "-" "_"}}_backend;
-      {{ else }}
-      # proxy_pass {{ $i.DefaultUrl $path }};
-      set $upstream_{{ $i.Name }}_{{ replace $path.Service "-" "_"}}_backend {{ $i.DefaultUrl $path }};
-      proxy_pass $upstream_{{ $i.Name }}_{{ replace $path.Service "-" "_"}}_backend;
-      {{ end }}
+      {{if $i.BlueGreen}}
+      # proxy_pass ${{$i.Name}}_{{replace $path.Service "-" "_"}}_backend;
+      set $upstream_{{$i.Name}}_{{replace $path.Service "-" "_"}}_backend ${{$i.Name}}_{{replace $path.Service "-" "_"}}_backend;
+      proxy_pass $upstream_{{$i.Name}}_{{replace $path.Service "-" "_"}}_backend;
+      {{else}}{{/* if $i.BlueGreen */}}
+      # proxy_pass {{$i.DefaultUrl $path}};
+      set $upstream_{{$i.Name}}_{{replace $path.Service "-" "_"}}_backend {{$i.DefaultUrl $path}};
+      proxy_pass $upstream_{{$i.Name}}_{{replace $path.Service "-" "_"}}_backend;
+      {{end}}{{/* if $i.BlueGreen */}}
     }
-{{end}}
-  }{{end}}
+    {{end}}{{/* range $path := $i.Paths */}}
+  }
+{{end}}{{/* if $i.Host */}}
+{{end}}{{/* range $i := . */}}
 }


### PR DESCRIPTION
Fixes so that when no host is defined within an ingress it will no longer generate an nginx configuration value for the ingress.

Bitesize PR @ https://github.com/pearsontechnology/bitesize/pull/825
Tests PR @ https://github.com/pearsontechnology/kubernetes-tests/pull/16
Ingress PR @ https://github.com/pearsontechnology/bitesize-controllers/pull/15

Testing local requires adding

```
ingress_version = "1.8.3"
```

to your local .tfvars file