### PR TITLE
Bite 1446 nginx version and security headers, also includes COPS-165

### DIFF
--- a/nginx-ingress-vault/Dockerfile
+++ b/nginx-ingress-vault/Dockerfile
@@ -32,11 +32,14 @@ COPY favicon.ico /usr/share/nginx/html/
 # BITE-1345
 COPY dhparam.pem /etc/nginx/certs/
 
+# BITE-1446 - install curl for troubleshooting purposes
+RUN apt-get install curl
+
 # BITE-1428  - change user
-RUN touch /var/run/nginx.pid && chown -R nginx:nginx /var/run/nginx.pid && chown -R nginx:nginx /var/cache/nginx && \ 
+RUN touch /var/run/nginx.pid && chown -R nginx:nginx /var/run/nginx.pid && chown -R nginx:nginx /var/cache/nginx && \
     chown -R nginx:nginx /controller && chown -R nginx:nginx /etc/nginx/nginx.conf && chown -R nginx:nginx /usr/bin/run.sh && \
     chown -R nginx:nginx /etc/nginx && chown -R nginx:nginx /usr/share/nginx/html && chown -R nginx:nginx /etc/nginx/certs
-    
+
 # BITE-1428 - change user
 USER nginx
 

--- a/nginx-ingress-vault/Dockerfile
+++ b/nginx-ingress-vault/Dockerfile
@@ -14,6 +14,10 @@
 # BITE-1345 image source previously gcr.io/google-containers/nginx:latest
 
 FROM nginx:latest
+
+# BITE-1428 - change user
+USER root
+
 COPY controller /
 COPY default.conf /etc/nginx/nginx.conf
 COPY /run.sh /usr/bin/run.sh
@@ -27,5 +31,13 @@ COPY pearson_logo.png /usr/share/nginx/html/
 COPY favicon.ico /usr/share/nginx/html/
 # BITE-1345
 COPY dhparam.pem /etc/nginx/certs/
+
+# BITE-1428  - change user
+RUN touch /var/run/nginx.pid && chown -R nginx:nginx /var/run/nginx.pid && chown -R nginx:nginx /var/cache/nginx && \ 
+    chown -R nginx:nginx /controller && chown -R nginx:nginx /etc/nginx/nginx.conf && chown -R nginx:nginx /usr/bin/run.sh && \
+    chown -R nginx:nginx /etc/nginx && chown -R www-data:www-data /usr/share/nginx/html && chown -R www-data:www-data /etc/nginx/certs
+    
+# BITE-1428 - change user
+USER nginx
 
 CMD ["/usr/bin/run.sh"]

--- a/nginx-ingress-vault/Dockerfile
+++ b/nginx-ingress-vault/Dockerfile
@@ -32,9 +32,6 @@ COPY favicon.ico /usr/share/nginx/html/
 # BITE-1345
 COPY dhparam.pem /etc/nginx/certs/
 
-# BITE-1446 - install curl for troubleshooting purposes
-RUN apt-get install curl
-
 # BITE-1428  - change user
 RUN touch /var/run/nginx.pid && chown -R nginx:nginx /var/run/nginx.pid && chown -R nginx:nginx /var/cache/nginx && \
     chown -R nginx:nginx /controller && chown -R nginx:nginx /etc/nginx/nginx.conf && chown -R nginx:nginx /usr/bin/run.sh && \

--- a/nginx-ingress-vault/Dockerfile
+++ b/nginx-ingress-vault/Dockerfile
@@ -15,9 +15,6 @@
 
 FROM nginx:latest
 
-# BITE-1428 - change user
-USER root
-
 COPY controller /
 COPY default.conf /etc/nginx/nginx.conf
 COPY /run.sh /usr/bin/run.sh
@@ -31,14 +28,5 @@ COPY pearson_logo.png /usr/share/nginx/html/
 COPY favicon.ico /usr/share/nginx/html/
 # BITE-1345
 COPY dhparam.pem /etc/nginx/certs/
-
-# BITE-1428  - change user
-RUN touch /var/run/nginx.pid && chown -R nginx:nginx /var/run/nginx.pid && chown -R nginx:nginx /var/cache/nginx && \
-    chown -R nginx:nginx /controller && chown -R nginx:nginx /etc/nginx/nginx.conf && chown -R nginx:nginx /usr/bin/run.sh && \
-    chown -R nginx:nginx /etc/nginx && chown -R nginx:nginx /usr/share/nginx/html && chown -R nginx:nginx /etc/nginx/certs && \
-    chown -R nginx:nginx /etc/ssl/certs
-    
-# BITE-1428 - change user
-USER nginx
 
 CMD ["/usr/bin/run.sh"]

--- a/nginx-ingress-vault/controller.go
+++ b/nginx-ingress-vault/controller.go
@@ -33,7 +33,7 @@ import (
     log "github.com/Sirupsen/logrus"
 )
 
-const version = "1.8.6"
+const version = "1.8.7"
 
 func main() {
 

--- a/nginx-ingress-vault/nginx.conf.tmpl
+++ b/nginx-ingress-vault/nginx.conf.tmpl
@@ -79,7 +79,9 @@ http {
   {{end}}{{/* if $i.BlueGreen */}}
   {{if not $i.Nonssl}}
   server {
-  # cops-479 - Add 301 redirect if httpsOnly is set to true.
+    # BITE-1446 NGINX security improvements - Remove NGINX version number
+    server_tokens off;
+    # cops-479 - Add 301 redirect if httpsOnly is set to true.
     listen  80;
     server_name {{$i.Host}};
     resolver kube-dns.kube-system.svc.cluster.local;
@@ -88,6 +90,8 @@ http {
   {{end}}{{/* if not $i.Nonssl */}}
 
   server {
+    # BITE-1446 NGINX security improvements - Remove NGINX version number
+    server_tokens off;
     server_name {{$i.Host}};
     resolver kube-dns.kube-system.svc.cluster.local;
     {{if $i.Ssl}}
@@ -108,7 +112,9 @@ http {
         # Add header in 3XX 4XX and 5XX will only work in Nginx > 1.7
         add_header X-Loadbalancer-Id {{$i.GetPodName}};
         add_header X-Upstream-IP $upstream_addr;
-
+        # BITE-1446 NGINX security improvements - Security Headers
+        add_header X-Content-Type-Options nosniff;
+        add_header X-XSS-Protection "1; mode=block";
         root /usr/share/nginx/html;
     }
 
@@ -117,6 +123,9 @@ http {
       proxy_set_header Host $host;
       # cops-374 - Will forward the Nginx pod name as a custom header
       add_header X-Loadbalancer-Id {{$i.GetPodName}};
+      # BITE-1446 NGINX security improvements - Security Headers
+      add_header X-Content-Type-Options nosniff;
+      add_header X-XSS-Protection "1; mode=block";
       {{if $i.BlueGreen}}
       # proxy_pass ${{$i.Name}}_{{replace $path.Service "-" "_"}}_backend;
       set $upstream_{{$i.Name}}_{{replace $path.Service "-" "_"}}_backend ${{$i.Name}}_{{replace $path.Service "-" "_"}}_backend;


### PR DESCRIPTION
Bitesize PR template. 

Please fill out all of the fields below. Where fields are not applicable please state why

- **What does the PR do?** *nginx-ingress upgrade to 1.8.7 including BITE-1446 (extend nginx version suppression and security headers to all nginx server contexts) and COPS-165 (custom error page notifications)*
- **How should this be tested manually?** *Use Google Chrome to browse to application on Bitesize using Developer tools, examine HTTP response headers. nginx header should have no version number, should be 2 security headers present: X-Xss-Protection, X-Content-Type-Options*
- **Does this need customer facing documentation?** *completed: https://docs.prsn.io/docs/howto/security_headers*
- **Does this need internal facing documentation?** *no*
- **Any dependencies?** *no*
- **What automated testing exists for this change?** *existing Travis tests*
- [x] **Has the changelog been updated?** *yes* 
- **What is the release process for this change?** *change to instance variable for ingress version, delete old nginx-ingress pods, automatically create new nginx-ingress pods, outage not required*
- **What's the risk if this change fails?** *loss of application or degraded application functionality*
- **What's the rollback process?** *revert instance variable for ingress version* 