### PR TITLE
BITE-1469 - NGINX Sidecar

### DIFF
--- a/nginx-ingress-vault/Dockerfile
+++ b/nginx-ingress-vault/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 # BITE-1345 image source previously gcr.io/google-containers/nginx:latest
 
-FROM nginx:1.13.0
+FROM nginx:1.12.0
 RUN apt update && apt install -y openssl procps
 COPY controller /
 COPY default.conf /etc/nginx/nginx.conf

--- a/nginx-ingress-vault/controller.go
+++ b/nginx-ingress-vault/controller.go
@@ -33,7 +33,7 @@ import (
     log "github.com/Sirupsen/logrus"
 )
 
-const version = "1.8.8"
+const version = "1.8.10"
 
 func main() {
 

--- a/nginx-ingress-vault/nginx.conf.tmpl
+++ b/nginx-ingress-vault/nginx.conf.tmpl
@@ -84,7 +84,7 @@ http {
     # cops-479 - Add 301 redirect if httpsOnly is set to true.
     listen  80;
     server_name {{$i.Host}};
-    resolver 127.0.0.1:53;
+    resolver {{$i.GetResolver}}:{{$i.GetResolverPort}};
     return  301  https://$server_name$request_uri;
   }
   {{end}}{{/* if not $i.Nonssl */}}
@@ -93,7 +93,7 @@ http {
     # BITE-1446 NGINX security improvements - Remove NGINX version number
     server_tokens off;
     server_name {{$i.Host}};
-    resolver 127.0.0.1:53;
+    resolver {{$i.GetResolver}}:{{$i.GetResolverPort}};
     {{if $i.Ssl}}
     listen 443 ssl;
     ssl_certificate   /etc/nginx/certs/{{$i.Host}}.crt;

--- a/nginx-ingress-vault/nginx.conf.tmpl
+++ b/nginx-ingress-vault/nginx.conf.tmpl
@@ -84,7 +84,7 @@ http {
     # cops-479 - Add 301 redirect if httpsOnly is set to true.
     listen  80;
     server_name {{$i.Host}};
-    resolver kube-dns.kube-system.svc.cluster.local;
+    resolver 127.0.0.1:53;
     return  301  https://$server_name$request_uri;
   }
   {{end}}{{/* if not $i.Nonssl */}}
@@ -93,7 +93,7 @@ http {
     # BITE-1446 NGINX security improvements - Remove NGINX version number
     server_tokens off;
     server_name {{$i.Host}};
-    resolver kube-dns.kube-system.svc.cluster.local;
+    resolver 127.0.0.1:53;
     {{if $i.Ssl}}
     listen 443 ssl;
     ssl_certificate   /etc/nginx/certs/{{$i.Host}}.crt;

--- a/nginx-ingress-vault/nginx/virtual_host.go
+++ b/nginx-ingress-vault/nginx/virtual_host.go
@@ -135,6 +135,14 @@ func (vhost *VirtualHost) GetPodName() string {
     return os.Getenv("POD_NAME")
 }
 
+func (vhost *VirtualHost) GetResolver() string {
+    return os.Getenv("RESOLVER")
+}
+
+func (vhost *VirtualHost) GetResolverPort() string {
+    return os.Getenv("RESOLVER_PORT")
+}
+
 func (vhost *VirtualHost) DefaultUrl(path Path) string {
     return fmt.Sprintf("%s://%s.%s.svc.cluster.local:%d", vhost.Scheme, path.Service, vhost.Namespace, path.Port)
 }
@@ -156,4 +164,3 @@ func newHTTPClient(dest *url.URL) *http.Client {
     }
     return &http.Client{}
 }
-


### PR DESCRIPTION
This change updates the nginx.conf template to use localhost for its resolver. This ensures the sidecar dnsmasq implemenation here: is utilized for resolution instead of kube-dns.
