### PR TITLE
BITE-2193 Ensure errors on first start avoided

### DIFF
--- a/nginx-ingress-vault/controller.go
+++ b/nginx-ingress-vault/controller.go
@@ -74,6 +74,9 @@ func main() {
                 time.Sleep(reloadFrequency)
                 continue
             }
+            if vault.Enabled {
+                go vault.RenewToken()
+            }    
         }
 
         if !vault.Ready() {

--- a/nginx-ingress-vault/controller.go
+++ b/nginx-ingress-vault/controller.go
@@ -31,7 +31,7 @@ import (
     log "github.com/Sirupsen/logrus"
 )
 
-const version = "1.9.6"
+const version = "1.9.7"
 
 func main() {
 
@@ -68,20 +68,24 @@ func main() {
     // Controller loop
     for {
 
-        time.Sleep(reloadFrequency)
+        if !vault.Enabled {
+            vault, err = vlt.NewVaultReader()
+            if err != nil {
+                time.Sleep(reloadFrequency)
+                continue
+            }
+        }
 
         if !vault.Ready() {
             vault, err = vlt.NewVaultReader()
-            if err !=nil {
-                continue
-            }
+
             // Reset existing ingress list to allow pull of ssl from vault
             known = &v1beta1.IngressList{}
-            
-            if vault.Enabled {
-                go vault.RenewToken()
-            }
+            time.Sleep(reloadFrequency)
+            continue
         }
+
+        time.Sleep(reloadFrequency)
 
         ingresses, err := k8s.GetIngresses(onKubernetes)
 

--- a/nginx-ingress-vault/nginx.conf.tmpl
+++ b/nginx-ingress-vault/nginx.conf.tmpl
@@ -92,10 +92,10 @@ http {
   server {
     # BITE-1446 NGINX security improvements - Remove NGINX version number
     server_tokens off;
+    listen 443 ssl;
     server_name {{$i.Host}};
     resolver {{$i.GetResolver}}:{{$i.GetResolverPort}};
     {{if $i.Ssl}}
-    listen 443 ssl;
     ssl_certificate   /etc/nginx/certs/{{$i.Host}}.crt;
     ssl_certificate_key /etc/nginx/certs/{{$i.Host}}.key;
     {{end}}{{/* if $i.Ssl */}}

--- a/nginx-ingress-vault/vault/vault_reader.go
+++ b/nginx-ingress-vault/vault/vault_reader.go
@@ -25,16 +25,16 @@ type Cert struct {
     Secret string
 }
 
-func getToken()(token string) {
+func getToken() (token string, err error) {
 
     token = os.Getenv("VAULT_TOKEN")
     secretKey := os.Getenv("VAULT_TOKEN_SECRET")
     if token == "" {
         if secretKey == "" {
-            return token
+            return token, nil
         }
     } else {
-        return token
+        return token, nil
     }
 
     namespace := os.Getenv("POD_NAMESPACE")
@@ -54,7 +54,7 @@ func getToken()(token string) {
 
     if err != nil {
         log.Errorf("Error retrieving secrets: %v", err)
-        return ""
+        return "", nil
     }
 
     for name, data := range secrets.Data {
@@ -68,16 +68,18 @@ func getToken()(token string) {
     if err != nil {
         log.Errorf("Error parsing VAULT_TOKEN_SECRET: %v", token)
     }
-    return token
+    return token, err
 }
 
 func NewVaultReader() (*VaultReader, error) {
     enabledFlag := os.Getenv("VAULT_ENABLED")
     address := os.Getenv("VAULT_ADDR")
     refreshFlag := os.Getenv("VAULT_REFRESH_INTERVAL")
-    token := getToken()
+    token, err := getToken()
 
-    if token == "" {
+    if err == nil {
+        enabledFlag = "true"
+    } else {
         enabledFlag = "false"
     }
 

--- a/nginx-ingress-vault/vault/vault_reader.go
+++ b/nginx-ingress-vault/vault/vault_reader.go
@@ -72,25 +72,24 @@ func getToken() (token string, err error) {
 }
 
 func NewVaultReader() (*VaultReader, error) {
-    enabledFlag := os.Getenv("VAULT_ENABLED")
     address := os.Getenv("VAULT_ADDR")
     refreshFlag := os.Getenv("VAULT_REFRESH_INTERVAL")
+    enabled, err := strconv.ParseBool(os.Getenv("VAULT_ENABLED"))
+    if err != nil {
+        enabled = true
+    }
+
     token, err := getToken()
 
     if err == nil {
-        enabledFlag = "true"
+        enabled = true
     } else {
-        enabledFlag = "false"
+        enabled = false
     }
 
     refreshInterval, err := strconv.Atoi(refreshFlag)
     if err != nil {
         refreshInterval = 10
-    }
-
-    enabled, err := strconv.ParseBool(enabledFlag)
-    if err != nil {
-        enabled = true
     }
 
     if address == "" || token == "" {


### PR DESCRIPTION
 and retries vault config if first disabled.

Errors were caused by wrong ordering of listen in the nginx.conf tmpl.

Not retrying vault config was a result of poor logic on error handling.

Startup should be clean and it will retry vault on each sleep interval.