### PR TITLE
BITE-2432 - Add retries for vault in ingress controller

### DIFF
--- a/nginx-ingress-vault/controller.go
+++ b/nginx-ingress-vault/controller.go
@@ -31,7 +31,7 @@ import (
     log "github.com/Sirupsen/logrus"
 )
 
-const version = "1.9.7"
+const version = "1.9.8"
 
 func main() {
 

--- a/nginx-ingress-vault/controller.go
+++ b/nginx-ingress-vault/controller.go
@@ -42,7 +42,7 @@ func main() {
         log.SetLevel(log.DebugLevel)
     }
 
-    log.Infof("\n Ingress Controller version: %v", version)
+    log.Infof("Ingress Controller version: %v", version)
 
     v := os.Getenv("RELOAD_FREQUENCY")
     reloadFrequency, err := time.ParseDuration(v)
@@ -76,7 +76,7 @@ func main() {
             }
             if vault.Enabled {
                 go vault.RenewToken()
-            }    
+            }
         }
 
         if !vault.Ready() {


### PR DESCRIPTION
Addresses likely cause of intermittent failures to retrieve secrets:


{"log":"{\"level\":\"info\",\"msg\":\"Error retrieving vault status\",\"time\":\"2018-03-26T13:14:21Z\"}\n","stream":"stderr","time":"2018-03-26T13:14:21.974672607Z"}
{"log":"{\"level\":\"info\",\"msg\":\"Error retrieving vault status\",\"time\":\"2018-03-26T13:14:41Z\"}\n","stream":"stderr","time":"2018-03-26T13:14:41.970906807Z"}

Observed during testing this fix, which seems to back this up:

 {"level":"info","msg":"Ingress Controller version: 1.9.7","time":"2018-03-28T15:54:26Z"}
{"level":"info","msg":"Found VAULT_TOKEN_SECRET secret: vault-ingress-read-only","time":"2018-03-28T15:54:27Z"}
{"level":"info","msg":"Error retrieving vault status: \u003cnil\u003e, Get https://vault.kube-system.svc.cluster.local:8243/v1/sys/seal-status: dial tcp: lookup vault.kube-system.svc.cluster.local: Temporary failure in name resolution","time":"2018-03-28T15:54:27Z"}
{"level":"error","msg":"No secret for auth.mdev.us-west-2.prsn-dev.io\n","time":"2018-03-28T15:54:33Z"}
{"level":"error","msg":"No secret for uapi.mdev.us-west-2.prsn-dev.io\n","time":"2018-03-28T15:54:33Z"}
{"level":"info","msg":"Found secret for vault.mdev.us-west-2.dev","time":"2018-03-28T15:54:33Z"}
