### PR TITLE
BITE-2489 Add http2 support

### DIFF
--- a/nginx-ingress-vault/README.md
+++ b/nginx-ingress-vault/README.md
@@ -165,4 +165,14 @@ You should now be able to point www.example.com at the Ingress nodes and reach w
 
 If either VAULT_ADDR or VAULT_TOKEN are not set then vault support is disabled and the controller should act like nginx-alpha, with the addition of access and err logging from the nginx instance to stdout/err on the container.
 
+Other labels:
+
+```
+http2: "true"
+httpsBackend: "true"
+httpsOnly: "true"
+ssl: "true"
+```
+Note that if http2 is enabled then ssl and httpsOnly should also be true.
+
 # End

--- a/nginx-ingress-vault/controller.go
+++ b/nginx-ingress-vault/controller.go
@@ -31,7 +31,7 @@ import (
     log "github.com/Sirupsen/logrus"
 )
 
-const version = "1.9.8"
+const version = "1.9.9"
 
 func main() {
 

--- a/nginx-ingress-vault/nginx.conf.tmpl
+++ b/nginx-ingress-vault/nginx.conf.tmpl
@@ -92,7 +92,11 @@ http {
   server {
     # BITE-1446 NGINX security improvements - Remove NGINX version number
     server_tokens off;
+    {{ if $i.Http2 }}
+    listen 443 http2 ssl;
+    {{ else }}
     listen 443 ssl;
+    {{end}}{{/* if $i.Http2 */}}
     server_name {{$i.Host}};
     resolver {{$i.GetResolver}}:{{$i.GetResolverPort}};
     {{if $i.Ssl}}


### PR DESCRIPTION
Enables support for http2.

Add label http2: "true"

Default=false.

Note that if http2 is enabled, sssl and httpsOnly must also be true.