### PR TITLE
BITE-3042 Ensure periodic tokens

### DIFF
--- a/vault-controller/vault/vault_client.go
+++ b/vault-controller/vault/vault_client.go
@@ -146,7 +146,7 @@ func (c *VaultClient) CreatePolicy(policy vaultpolicy.VaultPolicy) (token string
     opts := &vault.TokenCreateRequest{
         Policies: policies,
         DisplayName: policy.Name,
-		Lease: "24h"}
+		Period: "24h"}
 
     log.Infof("Creating token for policy: %v", policy.Name )
     log.Debugf("CreatePolicy token opts: %v", opts)


### PR DESCRIPTION
The policy monitor should create periodic tokens to ensure they don't expire