### PR TITLE
BITE-3042 - Add Period and TTL to Policy CRD

### DIFF
--- a/vault-controller/README.md
+++ b/vault-controller/README.md
@@ -144,9 +144,10 @@ metadata:
 spec:
   - Path: secret/mysecrets/*
     Permission: read
+    Period: 24h
 
 ```
 
-In this case a policy 'vault-mysecrets-read-only' would be created and a token for it stashed in my-ns/vault-mysecrets-read-only:vault-mysecrets-read-only. The default TTL for the token is 24h.
+In this case a policy 'vault-mysecrets-read-only' would be created and a periodic token for it stashed in my-ns/vault-mysecrets-read-only:vault-mysecrets-read-only. A TTL may be specified in place of Period, the default TTL in this case is 720h. If Period is specified however, TTL is ignored.
 
 ## End

--- a/vault-controller/pkg/apis/vault.local/v1/types.go
+++ b/vault-controller/pkg/apis/vault.local/v1/types.go
@@ -17,6 +17,8 @@ type VaultPolicy struct {
 type VaultPolicySpec struct {
     Path       string `json:"path"`
 	Permission string `json:"permission"`
+    TTL        string `json:"ttl"`
+    Period     string `json:"period"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/vault-controller/vault/vault_client.go
+++ b/vault-controller/vault/vault_client.go
@@ -142,11 +142,20 @@ func (c *VaultClient) CreatePolicy(policy vaultpolicy.VaultPolicy) (token string
     }
     log.Infof("CreatePolicy created policy: %v", policy.Name)
     var policies []string
+
     policies = append(policies, policy.Name)
+
     opts := &vault.TokenCreateRequest{
         Policies: policies,
-        DisplayName: policy.Name,
-		Period: "24h"}
+        DisplayName: policy.Name}
+
+    for _, s := range policy.Spec {
+        if len(s.Period) > 0 {
+            opts.Period = s.Period
+        } else if len(s.TTL) > 0 {
+            opts.TTL = s.TTL
+        }
+    }
 
     log.Infof("Creating token for policy: %v", policy.Name )
     log.Debugf("CreatePolicy token opts: %v", opts)


### PR DESCRIPTION
Adds Period or TTL flag to VaultPolicy:

```apiVersion: vault.local/v1
kind: VaultPolicy
metadata:
  name: vault-ingress-read-only
  namespace: kube-system
  labels:
    name: vault-ingress-read-only
    app: bitesize
spec:
  - Path: secret/ssl/*
    Permission: read
    Period: 1h
```

Produces:

```Using VAULT_TOKEN_FILE: /etc/vault-token-file/root-token...
Key              	Value
---              	-----
accessor         	ba48ae24-0979-fc26-d83b-aea24a4ebd44
creation_time    	1530012186
creation_ttl     	3600
display_name     	token-vault-ingress-read-only
entity_id        	
expire_time      	2018-06-26T13:43:32.750391312Z
explicit_max_ttl 	0
id               	0952f47b-a852-5881-5fa7-826117271900
issue_time       	2018-06-26T11:23:06.605348519Z
last_renewal     	2018-06-26T12:43:32.750392625Z
last_renewal_time	1530017012
meta             	<nil>
num_uses         	0
orphan           	false
path             	auth/token/create
period           	3600
policies         	[default vault-ingress-read-only]
renewable        	true
ttl              	3477
```