### PR TITLE
compile updated version of nginx with vts module to get per vhost stats

### DIFF
--- a/nginx-ingress-vault/Dockerfile
+++ b/nginx-ingress-vault/Dockerfile
@@ -144,11 +144,6 @@ STOPSIGNAL SIGQUIT
 ## Bitesize
 
 
-COPY controller /
-COPY default.conf /etc/nginx/nginx.conf
-COPY /run.sh /usr/bin/run.sh
-RUN chmod +x /usr/bin/run.sh
-COPY nginx.conf.tmpl /etc/nginx/
 # cops-165
 COPY error_page.tmpl /etc/nginx/
 # To overide the default nginx page
@@ -157,5 +152,11 @@ COPY pearson_logo.png /usr/share/nginx/html/
 COPY favicon.ico /usr/share/nginx/html/
 # BITE-1345
 COPY dhparam.pem /etc/nginx/certs/
+
+COPY default.conf /etc/nginx/nginx.conf
+COPY controller /
+COPY /run.sh /usr/bin/run.sh
+RUN chmod +x /usr/bin/run.sh
+COPY nginx.conf.tmpl /etc/nginx/
 
 CMD ["/usr/bin/run.sh"]

--- a/nginx-ingress-vault/Dockerfile
+++ b/nginx-ingress-vault/Dockerfile
@@ -1,20 +1,149 @@
-# Copyright 2015 The Kubernetes Authors. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# BITE-1345 image source previously gcr.io/google-containers/nginx:latest
+FROM alpine:3.8
 
-FROM nginx:1.12.0
-RUN apt update && apt install -y openssl procps telnet curl vim wget
+ENV NGINX_VERSION 1.12.2
+ENV VTS_VERSION 0.1.18
+
+RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
+                && CONFIG="\
+		--prefix=/etc/nginx \
+		--sbin-path=/usr/sbin/nginx \
+		--modules-path=/usr/lib/nginx/modules \
+		--conf-path=/etc/nginx/nginx.conf \
+		--error-log-path=/var/log/nginx/error.log \
+		--http-log-path=/var/log/nginx/access.log \
+		--pid-path=/var/run/nginx.pid \
+		--lock-path=/var/run/nginx.lock \
+		--http-client-body-temp-path=/var/cache/nginx/client_temp \
+		--http-proxy-temp-path=/var/cache/nginx/proxy_temp \
+		--http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp \
+		--http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp \
+		--http-scgi-temp-path=/var/cache/nginx/scgi_temp \
+		--user=nginx \
+		--group=nginx \
+		--with-http_ssl_module \
+		--with-http_realip_module \
+		--with-http_addition_module \
+		--with-http_sub_module \
+		--with-http_dav_module \
+		--with-http_flv_module \
+		--with-http_mp4_module \
+		--with-http_gunzip_module \
+		--with-http_gzip_static_module \
+		--with-http_random_index_module \
+		--with-http_secure_link_module \
+		--with-http_stub_status_module \
+		--with-http_auth_request_module \
+		--with-http_xslt_module=dynamic \
+		--with-http_image_filter_module=dynamic \
+		--with-http_geoip_module=dynamic \
+		--with-threads \
+		--with-stream \
+		--with-stream_ssl_module \
+		--with-stream_ssl_preread_module \
+		--with-stream_realip_module \
+		--with-stream_geoip_module=dynamic \
+		--with-http_slice_module \
+		--with-mail \
+		--with-mail_ssl_module \
+		--with-compat \
+		--with-file-aio \
+		--with-http_v2_module \
+        --add-module=/usr/src/nginx-module-vts-$VTS_VERSION \
+	" \
+	&& addgroup -S nginx \
+	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx \
+	&& apk add --no-cache --virtual .build-deps \
+		gcc \
+		libc-dev \
+		make \
+		openssl-dev \
+		pcre-dev \
+		zlib-dev \
+		linux-headers \
+		curl \
+		gnupg \
+		libxslt-dev \
+		gd-dev \
+		geoip-dev \
+	&& curl -fSL http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz -o nginx.tar.gz \
+	&& curl -fSL http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz.asc  -o nginx.tar.gz.asc \
+    && curl -fSL https://github.com/vozlt/nginx-module-vts/archive/v$VTS_VERSION.tar.gz  -o nginx-modules-vts.tar.gz \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& found=''; \
+	for server in \
+		ha.pool.sks-keyservers.net \
+		hkp://keyserver.ubuntu.com:80 \
+		hkp://p80.pool.sks-keyservers.net:80 \
+		pgp.mit.edu \
+	; do \
+		echo "Fetching GPG key $GPG_KEYS from $server"; \
+		gpg --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$GPG_KEYS" && found=yes && break; \
+	done; \
+	test -z "$found" && echo >&2 "error: failed to fetch GPG key $GPG_KEYS" && exit 1; \
+	gpg --batch --verify nginx.tar.gz.asc nginx.tar.gz \
+	&& rm -r "$GNUPGHOME" nginx.tar.gz.asc \
+	&& mkdir -p /usr/src \
+	&& tar -zxC /usr/src -f nginx.tar.gz \
+    && tar -zxC /usr/src -f nginx-modules-vts.tar.gz \
+	&& rm nginx.tar.gz nginx-modules-vts.tar.gz \
+	&& cd /usr/src/nginx-$NGINX_VERSION \
+	&& ./configure $CONFIG --with-debug \
+	&& make -j$(getconf _NPROCESSORS_ONLN) \
+	&& mv objs/nginx objs/nginx-debug \
+	&& mv objs/ngx_http_xslt_filter_module.so objs/ngx_http_xslt_filter_module-debug.so \
+	&& mv objs/ngx_http_image_filter_module.so objs/ngx_http_image_filter_module-debug.so \
+	&& mv objs/ngx_http_geoip_module.so objs/ngx_http_geoip_module-debug.so \
+	&& mv objs/ngx_stream_geoip_module.so objs/ngx_stream_geoip_module-debug.so \
+	&& ./configure $CONFIG \
+	&& make -j$(getconf _NPROCESSORS_ONLN) \
+	&& make install \
+	&& rm -rf /etc/nginx/html/ \
+	&& mkdir /etc/nginx/conf.d/ \
+	&& mkdir -p /usr/share/nginx/html/ \
+	&& install -m644 html/index.html /usr/share/nginx/html/ \
+	&& install -m644 html/50x.html /usr/share/nginx/html/ \
+	&& install -m755 objs/nginx-debug /usr/sbin/nginx-debug \
+	&& install -m755 objs/ngx_http_xslt_filter_module-debug.so /usr/lib/nginx/modules/ngx_http_xslt_filter_module-debug.so \
+	&& install -m755 objs/ngx_http_image_filter_module-debug.so /usr/lib/nginx/modules/ngx_http_image_filter_module-debug.so \
+	&& install -m755 objs/ngx_http_geoip_module-debug.so /usr/lib/nginx/modules/ngx_http_geoip_module-debug.so \
+	&& install -m755 objs/ngx_stream_geoip_module-debug.so /usr/lib/nginx/modules/ngx_stream_geoip_module-debug.so \
+	&& ln -s ../../usr/lib/nginx/modules /etc/nginx/modules \
+	&& strip /usr/sbin/nginx* \
+	&& strip /usr/lib/nginx/modules/*.so \
+	&& rm -rf /usr/src/nginx-$NGINX_VERSION \
+	\
+	# Bring in gettext so we can get `envsubst`, then throw
+	# the rest away. To do this, we need to install `gettext`
+	# then move `envsubst` out of the way so `gettext` can
+	# be deleted completely, then move `envsubst` back.
+	&& apk add --no-cache --virtual .gettext gettext \
+	&& mv /usr/bin/envsubst /tmp/ \
+	\
+	&& runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' /usr/sbin/nginx /usr/lib/nginx/modules/*.so /tmp/envsubst \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)" \
+	&& apk add --no-cache --virtual .nginx-rundeps $runDeps \
+	&& apk del .build-deps \
+	&& apk del .gettext \
+	&& mv /tmp/envsubst /usr/local/bin/ \
+        && apk add --no-cache bash openssl curl wget \
+	\
+	# forward request and error logs to docker log collector
+	&& ln -sf /dev/stdout /var/log/nginx/access.log \
+	&& ln -sf /dev/stderr /var/log/nginx/error.log
+
+
+EXPOSE 80
+
+STOPSIGNAL SIGQUIT
+
+
+## Bitesize
+
+
 COPY controller /
 COPY default.conf /etc/nginx/nginx.conf
 COPY /run.sh /usr/bin/run.sh

--- a/nginx-ingress-vault/nginx.conf.tmpl
+++ b/nginx-ingress-vault/nginx.conf.tmpl
@@ -36,6 +36,8 @@ http {
   error_log /dev/stderr error;
   access_log /dev/stdout proxied_combined;
 
+  vhost_traffic_status_zone;
+
   server {
 
     # BITE-1368 Remove NGINX version number
@@ -57,6 +59,12 @@ http {
     }
     location /ELBHealthCheck {
       root /var/www/healthcheck/;
+    }
+    location /vts {
+      vhost_traffic_status_display;
+      vhost_traffic_status_display_format html;
+      allow 127.0.0.1/32;
+      deny all;
     }
     location /nginx_status { # Used by sysdig-agent only. Exclude in Nginx logs.
       stub_status on;

--- a/nginx-ingress-vault/nginx.conf.tmpl
+++ b/nginx-ingress-vault/nginx.conf.tmpl
@@ -64,7 +64,7 @@ http {
       vhost_traffic_status_display;
       vhost_traffic_status_display_format html;
       allow 127.0.0.1/32;
-      allow {{ getenv VTSWL "127.0.0.1/32" }};
+      allow {{ getenv "VTSWL" "127.0.0.1/32" }};
       deny all;
     }
     location /nginx_status { # Used by sysdig-agent only. Exclude in Nginx logs.

--- a/nginx-ingress-vault/nginx.conf.tmpl
+++ b/nginx-ingress-vault/nginx.conf.tmpl
@@ -64,6 +64,7 @@ http {
       vhost_traffic_status_display;
       vhost_traffic_status_display_format html;
       allow 127.0.0.1/32;
+      allow {{ getenv VTSWL "127.0.0.1/32" }};
       deny all;
     }
     location /nginx_status { # Used by sysdig-agent only. Exclude in Nginx logs.

--- a/nginx-ingress-vault/nginx.conf.tmpl
+++ b/nginx-ingress-vault/nginx.conf.tmpl
@@ -64,7 +64,6 @@ http {
       vhost_traffic_status_display;
       vhost_traffic_status_display_format html;
       allow 127.0.0.1/32;
-      allow {{ getenv "VTSWL" "127.0.0.1/32" }};
       deny all;
     }
     location /nginx_status { # Used by sysdig-agent only. Exclude in Nginx logs.

--- a/nginx-ingress-vault/nginx/nginx.go
+++ b/nginx-ingress-vault/nginx/nginx.go
@@ -57,6 +57,7 @@ func Template() (*template.Template, error) {
       "replace": func(str string, src string, dst string )  string {
         return strings.Replace(str, src, dst, -1)
       },
+      "getenv": getenv,
     }
     return template.New("nginx.conf.tmpl").Funcs(fm).ParseFiles("/etc/nginx/nginx.conf.tmpl")
 


### PR DESCRIPTION
- nginx 1.12.0 -> 1.12.2
- now custom compiled to get per-vhost stats
- moved to alpine 3.8
- enabled vhost stats under /vts